### PR TITLE
#160702691 Make text on screen readable and make drop menu background white

### DIFF
--- a/ui/css/main.css
+++ b/ui/css/main.css
@@ -122,7 +122,7 @@ body{
 }
 
 .main-header nav ul li:hover > ul.menu{
-    top: 25px;
+    bottom: -8.5em;
 } 
 .main-header .menu li a{
     width: 88%;
@@ -134,7 +134,7 @@ body{
 
 }
 .food-bg-covering{
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.9);
 }
 .pands, .about{
     padding: 0 2em 2em 2em;
@@ -153,6 +153,7 @@ body{
 .home-body{
     background: url("../images/food-Background.png")
 }
+
 
 /*---------------User ACCOUNT ENDS Here------------------*/
 
@@ -257,6 +258,7 @@ body{
 .bg{ /*body wrapper background*/
     padding: 50px 0 0 50px;
     background-image: url("../images/24hrs.png");
+    background-size: contain;
 }
 div.bg > div#center{
     width: 35em;

--- a/ui/home.html
+++ b/ui/home.html
@@ -24,7 +24,7 @@
                 
                 <li><a href="./products.html"><span><img src="./images/products.png" alt="avatar-icon" class="avatar-icon"></span>PRODUCTS/
                     <span><img src="./images/deliver-food-services.png" alt="avatar-icon" class="avatar-icon">SERVICES</a></li>
-
+                      
                 <li id="account"><a href="#"><span><img src="./images/avatar-icon.png" alt="avatar-icon" class="avatar-icon"></span>ACCOUNT</a>
                     <ul class="menu clearfix whitebg">
                         <li><a href="#"><span><img src="./images/track-order.png" alt="track-order-icon" class="home-icon"></span>TRACK


### PR DESCRIPTION
#### What does this PR do?
Have the text on screen more readable and drop-down menu properly set


#### Description of Task to be completed?
Having the following corrections on the UI template:
* On the *About us* page, make the text on screen more readable
* On the *Products and services* page, make the text on screen more readable
* Increase the opacity of the white layer between the text on the screen and the body
* Have the background of the *Accounts* drop-down white on the nav bar

#### How should this be manually tested?
* Clone repo and CD into it
* Navigate to the index.html page with chrome browser.
* Click on the nav menu to reveal details.

#### What are the relevant pivotal tracker stories?
[#160843741](https://www.pivotaltracker.com/story/show/160843741)

#### Screenshots (if appropriate)
![ui changes](https://user-images.githubusercontent.com/38951888/46194977-e71f4980-c2fa-11e8-9c6b-3d155a5fa069.gif)
